### PR TITLE
SAAS-1005 fix node syncing test logic, fix test syntax, remove BAD BA…

### DIFF
--- a/restart-galera-nodes/restart-galera-nodes.yml
+++ b/restart-galera-nodes/restart-galera-nodes.yml
@@ -66,7 +66,7 @@ actions:
         it=66
         until (ssh abricot@localhost -p 8101 -i /tmp/abricot -o StrictHostKeyChecking=no full-read-only); do
           echo "karaf ssh login not updated yet (iteration $i/$it)"
-          if [ $i >= $it ]; then
+          if [ $i -ge $it ]; then
             echo "Too long to start, something is wrong here... EXITING"
             exit 1
           fi
@@ -95,9 +95,9 @@ actions:
         service mysql start
         i=1
         it=66
-        until [ "$(mysql -Ns -e \"show global status like 'wsrep_local_state_comment'\" | awk '{print $NF}')" != "Synced"  ]; do
+        until [ "$(mysql -Ns -e "show global status like 'wsrep_local_state_comment'" | awk '{print $NF}')" == "Synced"  ]; do
           echo "$(date) not ready yet (iteration $i/$it)"
-          if [ $i >= $it ]; then
+          if [ $i -ge $it ]; then
             echo "Too long to start, something is wrong here... EXITING"
             exit 1
           fi


### PR DESCRIPTION
…D escapes too

- `until` loop was wrong
- escapes character in test was cause mysql error
- test for loop timeout exit was not shell compatible too

THAT WAS A MESS :trollface: 

JIRA issue: https://jira.jahia.org/browse/PAAS-1005

Short description:
